### PR TITLE
Added CLI option to specify the pcap flie

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ Namely you want to find a USB adapter with one of the following chipsets: Athero
   brew cask install wireshark-chmodbpf
 ```
 
+You need to dissociate from any AP before initiating the scanning:
+```
+sudo /System/Library/PrivateFrameworks/Apple80211.framework/Versions/Current/Resources/airport -z
+```
+
 ### Linux [tshark](https://www.wireshark.org/docs/man-pages/tshark.html) 
 ```
 sudo apt-get install tshark

--- a/howmanypeoplearearound/oui.py
+++ b/howmanypeoplearearound/oui.py
@@ -1,5 +1,7 @@
-from urllib.request import urlopen
-from urllib.request import Request
+try: #python3
+    from urllib.request import urlopen
+except: #python2
+    from urllib2 import urlopen
 
 
 def load_dictionary(file):
@@ -17,6 +19,6 @@ def load_dictionary(file):
 def download_oui(to_file):
     uri = 'http://standards-oui.ieee.org/oui/oui.txt'
     print("Trying to download current version of oui.txt from [%s] to file [%s]" % (uri, to_file))
-    oui_data = urlopen(Request(uri), timeout=10).read()
+    oui_data = urlopen(uri, timeout=10).read()
     with open(to_file, 'wb') as oui_file:
         oui_file.write(oui_data)


### PR DESCRIPTION
This can be helpful on MacOS where you can capture on the interface while still attached to the wifi (using the Wireless Diagnostic tool) or in general when you already have a pcap file.