### PR TITLE
Handle curses errors gracefully

### DIFF
--- a/howmanypeoplearearound/__main__.py
+++ b/howmanypeoplearearound/__main__.py
@@ -16,6 +16,7 @@ from howmanypeoplearearound.colors import *
 
 if os.name != 'nt':
     from pick import pick
+    import curses
 
 def which(program):
     """Determines whether program exists
@@ -126,7 +127,11 @@ def scan(adapter, scantime, verbose, dictionary, number, nearby, jsonprint, out,
                       ', '.join(netifaces.interfaces()))
                 sys.exit(1)
             title = 'Please choose the adapter you want to use: '
-            adapter, index = pick(netifaces.interfaces(), title)
+            try:
+                adapter, index = pick(netifaces.interfaces(), title)
+            except curses.error as e:
+                print('Please check your $TERM settings: %s' % (e))
+                sys.exit(1)
 
         print("Using %s adapter and scanning for %s seconds..." %
               (adapter, scantime))


### PR DESCRIPTION
Starting `howmanypeoplearearound` using `xterm-color` as `$TERM` resulted in:

```
Traceback (most recent call last):
  File "howmanypeoplearearound/__main__.py", line 131, in scan
    adapter, index = pick(netifaces.interfaces(), title)
  File "/home/juergen/python/pick/pick/__init__.py", line 191, in pick
    return picker.start()
  File "/home/juergen/python/pick/pick/__init__.py", line 177, in start
    return curses.wrapper(self._start)
  File "/usr/lib/python3.7/curses/__init__.py", line 94, in wrapper
    return func(stdscr, *args, **kwds)
  File "/home/juergen/python/pick/pick/__init__.py", line 173, in _start
    self.config_curses()
  File "/home/juergen/python/pick/pick/__init__.py", line 166, in config_curses
    curses.curs_set(0)
_curses.error: curs_set() returned ERR
```

Root cause: The [unmaintained `xterm-color`](https://bugs.archlinux.org/task/5117) terminfo doesn't have the `cursor_invisible` capability. 

Using this commit results in more "user-friendly" error message:
```
Please check your $TERM settings: curs_set() returned ERR
```