### PR TITLE
 Add tshark capture filter for probe-req

### DIFF
--- a/howmanypeoplearearound/__main__.py
+++ b/howmanypeoplearearound/__main__.py
@@ -144,9 +144,11 @@ def scan(adapter, scantime, verbose, dictionary, number, nearby, jsonprint, out,
             t1.start()
 
         dump_file = '/tmp/tshark-temp'
+        capture_filter = 'type mgt subtype probe-req'
         # Scan with tshark
         command = [tshark, '-I', '-i', adapter, '-a',
-                   'duration:' + scantime, '-w', dump_file]
+                   'duration:' + scantime, '-w', dump_file, '-f',
+                   capture_filter]
         if verbose:
             print(' '.join(command))
         run_tshark = subprocess.Popen(


### PR DESCRIPTION
This change adds a capture filter so that tshark only captures probe requests, ignoring all the other traffic that comes up when a wireless interface is listening in monitor mode.

It uses the following pcap capture filter: "type mgt subtype probe-req"
pcap-filter docs: https://www.tcpdump.org/manpages/pcap-filter.7.html

By using a pcap filter, there is less information in the temporary pcap file to parse. Hopefully this slightly optimizes the code.

PS. This is my first pull request! I hope it is helpful, but my sincerest apologies if this is irrelevant or unhelpful. Thanks again for sharing this project and your awesome documentation!