### PR TITLE
Add '-h' flag to view help menu

### DIFF
--- a/howmanypeoplearearound/__main__.py
+++ b/howmanypeoplearearound/__main__.py
@@ -58,7 +58,7 @@ def fileToMacSet(path):
         maclist = f.readlines()
     return set([x.strip() for x in maclist])
 
-@click.command()
+@click.command(context_settings=dict(help_option_names=['-h', '--help']))
 @click.option('-a', '--adapter', default='', help='adapter to use')
 @click.option('-z', '--analyze', default='', help='analyze file')
 @click.option('-s', '--scantime', default='60', help='time in seconds to scan')


### PR DESCRIPTION
Since there's a chance a user might use the `h` flag instead of the
`--help` flag, this commit will let them use both to view the help menu.