### PR TITLE
Fix brew install --cask command

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Namely you want to find a USB adapter with one of the following chipsets: Athero
 ### Mac OS X
 ```
   brew install wireshark
-  brew cask install wireshark-chmodbpf
+  brew install --cask wireshark-chmodbpf
 ```
 
 You need to dissociate from any AP before initiating the scanning:


### PR DESCRIPTION
> Error: `brew cask` is no longer a `brew` command. Use `brew <command> --cask` instead.