### PR TITLE
Capture tshark errors and display as warnings

### DIFF
--- a/howmanypeoplearearound/__main__.py
+++ b/howmanypeoplearearound/__main__.py
@@ -145,8 +145,8 @@ def scan(adapter, scantime, verbose, dictionary, number, nearby, jsonprint, out,
             t1.daemon = True
             t1.start()
 
-        tmpdir = tempfile.TemporaryDirectory()
-        dump_file = os.path.join(tmpdir.name, 'tshark-temp')
+        tmpdir = tempfile.mkdtemp()
+        dump_file = os.path.join(tmpdir, 'tshark-temp')
 
         # Scan with tshark
         # EP, 20240817: -Q flags silences non-essential output that we don't use anyway,
@@ -293,7 +293,8 @@ def scan(adapter, scantime, verbose, dictionary, number, nearby, jsonprint, out,
         if verbose:
             print("Wrote %d records to %s" % (len(cellphone_people), out))
     if tmpdir is not None:
-        tmpdir.cleanup()
+        os.remove(dump_file)
+        os.rmdir(tmpdir)
     return adapter
 
 


### PR DESCRIPTION
As discussed in [issue #64 ](https://github.com/schollz/howmanypeoplearearound/issues/64).

This PR proposes the following:
- capture the stderr output of tshark and display it as a warning (instead of silently ignoring it)
- use proper temporary file / directory mechanism for the output of tshark, to avoid collisions.

It has been written with Python 2 and 3 in mind, however I only tested it with Python 3.

I eventually chose not to move the output to `logging`, as it's a pretty heavy change that will also break compatibility.